### PR TITLE
feat:[임재범] 모든 사용자에게 보여지는 공통 AppBar 컴포넌트 [DIY-SALES-APP-UI 5]

### DIFF
--- a/flutter/buy_idea/lib/component/appBar/common_app_bar.dart
+++ b/flutter/buy_idea/lib/component/appBar/common_app_bar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../pages/account/select_sign_up_page.dart';
+
+class CommonAppBar extends StatelessWidget with PreferredSizeWidget {
+  const CommonAppBar({Key? key, required this.title}) : super(key: key);
+  final String title;
+
+
+
+  @override
+  Widget build(BuildContext context) {
+
+    return AppBar(
+      backgroundColor: Colors.lightGreen,
+      elevation:0.0,
+      title:GestureDetector(
+          child: Image.asset("assets/buydia_logo.png", width:100, height:50),
+          onTap: () {
+            Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) {
+                  return const SelectSignUpPage(); //최초페이지로 연결(나중엔 메인으로 가는 버튼으로 변경)
+                })
+            );}
+      ),
+
+
+      actions: [
+        SizedBox(child:TextField(), width:150, height: 50,),
+        GestureDetector(onTap: () {}, child: const Icon(Icons.search)),
+
+                IconButton(onPressed: () {}, icon: const Icon(Icons.add_shopping_cart_outlined)),
+
+          IconButton(
+              icon: const Icon(Icons.settings),
+              onPressed: () {
+                //설정 페이지 연결
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) {
+                      return const SelectSignUpPage();
+                    })
+                );}
+          )
+        ],
+
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+}


### PR DESCRIPTION
현재 최초페이지로 지정되어 있는 select_sign_up_page.dart 코드에서
import 'package:buy_idea/component/appBar/common_app_bar.dart';
import 'package:buy_idea/component/logo.dart';
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

import '../../utility/size.dart';

class SelectSignUpPage extends StatelessWidget{
  const SelectSignUpPage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: CommonAppBar(title: "바이디어"), //<<--이거 입력해서 확인.
      body: Padding(
        padding: const EdgeInsets.all(16.0),
        child: ListView(
          children: [
            SizedBox(height: 220),
            Logo(),
            SizedBox(width: large_gap, height: 90.0),
            SelectSignUpForm(),
          ],
        ),
      ),
    );
  }
}