### PR TITLE
feat: [박선호] 판매자용 메인페이지 UI [DIY-SALES-APP-UI 15][DIY-SALES-APP-UI 19]

### DIFF
--- a/flutter/buy_idea/lib/component/account/sign_in/sign_in_form.dart
+++ b/flutter/buy_idea/lib/component/account/sign_in/sign_in_form.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:buy_idea/api/spring_member_api.dart';
 import 'package:buy_idea/component/account/sign_in/sign_in_text_form.dart';
+import 'package:buy_idea/pages/seller/seller_main_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -19,9 +20,9 @@ class SignInForm extends StatefulWidget {
 
 class _SignInFormState extends State<SignInForm> {
   late List<bool> isSelected;
-  late String memberType;
   static const storage = FlutterSecureStorage();
   dynamic memberInfo = '';
+  dynamic memberType = '';
 
   final _formKey = GlobalKey<FormState>();
   final memberIdController = TextEditingController();
@@ -39,10 +40,16 @@ class _SignInFormState extends State<SignInForm> {
 
   _asyncMethod() async {
     memberInfo = await storage.read(key: 'userToken');
+    memberType = await storage.read(key: 'memberType');
 
     if (memberInfo != null) {
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const MainPage()));
+      debugPrint(memberInfo);
+      debugPrint(memberType);
+      if (memberType == '일반회원') {
+        Navigator.push(context, MaterialPageRoute(builder: (context) => const MainPage()));
+      } else if (memberType == '판매자') {
+        Navigator.push(context, MaterialPageRoute(builder: (context) => const SellerMainPage()));
+      }
     } else {
       debugPrint('로그인이 필요합니다');
     }
@@ -59,13 +66,13 @@ class _SignInFormState extends State<SignInForm> {
 
     if (SpringMemberApi.signInResponse.statusCode == 200) {
       debugPrint('통신 성공!');
-      var val = SpringMemberApi.signInResponse.body;
-      var account = Member.fromJson(jsonDecode(val));
+      var val = jsonDecode(utf8.decode(SpringMemberApi.signInResponse.bodyBytes));
+      var account = Member.fromJson(val);
 
       await storage.write(key: 'userToken', value: account.userToken);
-      storage.write(key: 'memberId', value: account.memberId);
-      storage.write(key: 'nickname', value: account.nickname);
-      storage.write(key: 'memberType', value: account.memberType.toString());
+      await storage.write(key: 'memberId', value: account.memberId);
+      await storage.write(key: 'nickname', value: account.nickname);
+      await storage.write(key: 'memberType', value: account.memberType);
 
       _signInSuccessShowDialog();
       debugPrint('접속 성공!');
@@ -151,8 +158,14 @@ class _SignInFormState extends State<SignInForm> {
               title: "🎉️",
               content: '환영합니다🥰 \n 홈으로 이동합니다.',
               onCustomButtonPressed: () {
-                Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => const MainPage()));
+                if (isSelected[0] == true) {
+                  Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => const MainPage()));
+                } else if (isSelected[0] == false) {
+                  Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => const SellerMainPage()));
+                }
+
               });
         });
   }

--- a/flutter/buy_idea/lib/component/seller/seller_common_app_bar.dart
+++ b/flutter/buy_idea/lib/component/seller/seller_common_app_bar.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class SellerCommonAppBar extends StatelessWidget with PreferredSizeWidget {
+  const SellerCommonAppBar({Key? key, required this.appBar, this.title, this.leading, this.actions}) : super(key: key);
+
+  final AppBar appBar;
+  final Widget? title;
+  final Widget? leading;
+  final List<Widget>? actions;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      shape: Border(bottom: BorderSide(color: Colors.grey, width: 0.3)),
+      iconTheme: IconThemeData(
+        color: Colors.black
+      ),
+      centerTitle: true,
+      title: title,
+      leading: leading,
+      actions: actions,
+      backgroundColor: Colors.white,
+      elevation: 0,
+    );
+  }
+
+  @override
+  // TODO: implement preferredSize
+  Size get preferredSize => Size.fromHeight(appBar.preferredSize.height);
+}

--- a/flutter/buy_idea/lib/component/seller/seller_drawer.dart
+++ b/flutter/buy_idea/lib/component/seller/seller_drawer.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+class SellerDrawer extends StatefulWidget {
+  const SellerDrawer({Key? key, required this.nickname}) : super(key: key);
+
+  final String nickname;
+
+  @override
+  State<SellerDrawer> createState() => _SellerDrawerState();
+}
+
+class _SellerDrawerState extends State<SellerDrawer> {
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        children: [
+          Container(
+            padding: EdgeInsets.all(20),
+            height: 160,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 30,
+                  backgroundImage: AssetImage('assets/default_profile_image.png'),
+                  backgroundColor: Colors.white,
+                ),
+                SizedBox(height: 20),
+                Text(widget.nickname, style: TextStyle(color: Colors.white),),
+              ],
+            ),
+            decoration: BoxDecoration(
+                color: Color(0xff2F4F4F),
+                borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(30),
+                    bottomRight: Radius.circular(30)
+                )
+            ),
+          ),
+          SizedBox(height: 30),
+          // Divider(),
+          ListTile(
+            onTap: (){},
+            leading: Icon(Icons.local_mall_outlined, color: Colors.black),
+            title: Text('상품 관리'),
+            trailing: Icon(Icons.navigate_next, color: Colors.black),
+          ),
+          Divider(),
+          ListTile(
+            onTap: (){},
+            leading: Icon(Icons.comment_outlined, color: Colors.black),
+            title: Text('후기 관리'),
+            trailing: Icon(Icons.navigate_next, color: Colors.black),
+          ),
+          Divider(),
+          ListTile(
+            onTap: (){},
+            leading: Icon(Icons.quiz_outlined, color: Colors.black),
+            title: Text('문의 관리'),
+            trailing: Icon(Icons.navigate_next, color: Colors.black),
+          ),
+          Divider(),
+          ListTile(
+            onTap: (){},
+            leading: Icon(Icons.local_shipping_outlined, color: Colors.black),
+            title: Text('배송 관리'),
+            trailing: Icon(Icons.navigate_next, color: Colors.black),
+          ),
+          Divider(),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/buy_idea/lib/main.dart
+++ b/flutter/buy_idea/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:buy_idea/pages/account/sign_in_page.dart';
 import 'package:buy_idea/pages/main_page.dart';
+import 'package:buy_idea/pages/seller/seller_main_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -12,14 +13,19 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'signUp',
-      initialRoute: "/sign-in",
-      routes: {
-        "/sign-in": (context) => const SignInPage(),
-        "/main-page" : (context) => const MainPage(),
+    return GestureDetector(
+      onTap: () {
+        FocusManager.instance.primaryFocus?.unfocus();
       },
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: 'signUp',
+        initialRoute: "/sign-in",
+        routes: {
+          "/sign-in": (context) => const SignInPage(),
+          "/main-page" : (context) => const MainPage(),
+        },
+      ),
     );
   }
 }

--- a/flutter/buy_idea/lib/pages/seller/seller_main_page.dart
+++ b/flutter/buy_idea/lib/pages/seller/seller_main_page.dart
@@ -1,0 +1,76 @@
+import 'package:buy_idea/component/seller/seller_common_app_bar.dart';
+import 'package:buy_idea/component/seller/seller_drawer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SellerMainPage extends StatefulWidget {
+  const SellerMainPage({Key? key}) : super(key: key);
+
+  @override
+  State<SellerMainPage> createState() => _SellerMainPageState();
+}
+
+class _SellerMainPageState extends State<SellerMainPage> {
+  static const storage = FlutterSecureStorage();
+  dynamic memberNickname = '';
+
+  int _selectedPageIndex = 0;
+
+  List _pages = [
+    Center(child: Text('주문 관리 페이지')),
+    Center(child: Text('내 정보 페이지')),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
+      _asyncMethod();
+    });
+  }
+
+  _asyncMethod() async {
+    memberNickname = await storage.read(key: 'nickname');
+    debugPrint(memberNickname);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      drawer: SellerDrawer(nickname: memberNickname),
+      appBar: SellerCommonAppBar(
+        appBar: AppBar(),
+        title: GestureDetector(
+          onTap: () {
+            Navigator.push(context, MaterialPageRoute(builder: (context) => const SellerMainPage()));
+          },
+          child: Image.asset('assets/buydia_logo.png', width: 100),
+        ),
+      ),
+      body: _pages[_selectedPageIndex],
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+            color: Colors.white10,
+            border: Border(top: BorderSide(color: Colors.grey, width: 0.3))
+        ),
+        child: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          elevation: 0,
+          selectedItemColor: Colors.black,
+          onTap: _onItemTapped,
+          currentIndex: _selectedPageIndex,
+          items: [
+            BottomNavigationBarItem(icon: Icon(Icons.inventory_outlined), label: '주문 관리'),
+            BottomNavigationBarItem(icon: Icon(Icons.account_circle_outlined), label: '내 정보')
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedPageIndex = index;
+    });
+  }
+}


### PR DESCRIPTION
항목
- main.dart 변경 사항 -> 모든 페이지에서 키보드가 올라왔을 때 빈 공간을 터치하면 키보드가 내려가도록 수정
- 로그인 시 멤버타입에 따라 각각 다른 메인페이지로 이동하도록 수정 (일반회원 메인페이지, 판매자 메인페이지)
- 판매자 메인페이지 UI 구현
- 판매자가 모든페이지에서 공통적으로 쓰는 App Bar UI 구현
- App Bar 좌측 메뉴버튼 클릭 시 페이지 이동 가능한 관리 목록들이 나열된 Drawer UI 구현
- 해당 판매자의 주문 목록들을 나열된 주문 관리 항목과 판매자의 정보에 대한 관리가 이루어지는 내 정보 항목이 있는
   Bottom Navigation Bar UI 구현