### PR TITLE
feat: [박선호] 판매자가 등록한 상품 리스트 현황 페이지 UI [DIY-SALES-APP-UI 25]

### DIFF
--- a/flutter/buy_idea/lib/component/seller/product_registration_status/handmade_product_registration_status_list.dart
+++ b/flutter/buy_idea/lib/component/seller/product_registration_status/handmade_product_registration_status_list.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class HandmadeProductRegistrationStatusList extends StatefulWidget {
+  const HandmadeProductRegistrationStatusList({Key? key}) : super(key: key);
+
+  @override
+  State<HandmadeProductRegistrationStatusList> createState() => _HandmadeProductRegistrationStatusListState();
+}
+
+class _HandmadeProductRegistrationStatusListState extends State<HandmadeProductRegistrationStatusList> {
+
+  List<String> _productTitle = [
+    '선물추천♡볼통통한 토끼 볼토 키링',
+    '⭐️2주소요⭐️ 뜨개 호보백 (61 colors)',
+    '✨하트 앨리스 키링✨ (핸드폰 줄 변경 가능👌)',
+  ];
+
+  List<String> _productContent = [
+    '어쩌구 저쩌구 토끼 라라라라라랄 볼토 블라블라블라 키링 두구두구두구두구 투구 갑옷 아무말대잔치토스',
+    '뜨개 호보백 2주일까 3주일까 모르겠지 61colors일까 62colors일까 궁금하지 나도 몰라 히히히히히',
+    '하트 앨리스 키링 이상한 나라의 엘리스 키키 핸드폰 줄 변경 가능일 수도 있고 아닐 수도 설명설명수박명수까스활명수'
+  ];
+
+  List<String> _starRate = ['4.8', '4.5', '4.9'];
+  List<String> _reviews = ['20', '55', '238'];
+  List<String> _productRegisterDate = ['2022/12/10', '2022/11/23', '2022/11/09'];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: ListView.builder(
+        shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+          itemCount: 3,
+          itemBuilder: (BuildContext buildContext, int index) {
+        return Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20, top: 10),
+          child: Card(
+            elevation: 5,
+            shape: RoundedRectangleBorder( borderRadius: BorderRadius.circular(10)),
+            child: InkWell(
+              onTap: (){},
+              child: Container(
+                height: 200,
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 180,
+                          height: 180,
+                          decoration: BoxDecoration(
+                            image: DecorationImage(
+                              fit: BoxFit.cover,
+                              image: AssetImage('assets/product/handmade${index+1}.jpg')
+                            ),
+                            borderRadius: BorderRadius.circular(15)
+                          ),
+                        ),
+                        VerticalDivider(),
+                        Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                    _productTitle[index],
+                                    style: TextStyle(fontSize: 13)
+                                ),
+                                Divider(thickness: 1,),
+                                Text(
+                                    _productContent[index],
+                                    maxLines: 3,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(fontSize: 11)
+                                ),
+                                Expanded(
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.end,
+                                    children: [
+                                      Row(
+                                        children: [
+                                          Icon(Icons.star_rate, color: Colors.amber, size: 14,),
+                                          SizedBox(width: 5),
+                                          Text(_starRate[index], style: TextStyle(fontSize: 12),),
+                                          Expanded(child: Text('별점', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                        ],
+                                      ),
+                                      SizedBox(height: 5),
+                                      Row(
+                                        children: [
+                                          Icon(Icons.rate_review_outlined, color: Colors.black, size: 14,),
+                                          SizedBox(width: 5),
+                                          Text(_reviews[index], style: TextStyle(fontSize: 12),),
+                                          Expanded(child: Text('후기', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                        ],
+                                      ),
+                                      SizedBox(height: 5),
+                                      Row(
+                                        children: [
+                                          Icon(Icons.edit_calendar_outlined, color: Colors.black, size: 14,),
+                                          SizedBox(width: 5),
+                                          Text(_productRegisterDate[index], style: TextStyle(fontSize: 12),),
+                                          Expanded(child: Text('등록일', style: TextStyle(fontSize: 12), textAlign: TextAlign.end,))
+                                        ],
+                                      )
+                                    ],
+                                  ),
+                                )
+                              ],
+                            )
+                        )
+                      ],
+                    ),
+                  )
+              ),
+            ),
+          ),
+        );
+      })
+    );
+  }
+}

--- a/flutter/buy_idea/lib/component/seller/product_registration_status/hobby_product_registration_status_list.dart
+++ b/flutter/buy_idea/lib/component/seller/product_registration_status/hobby_product_registration_status_list.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+class HobbyProductRegistrationStatusList extends StatefulWidget {
+  const HobbyProductRegistrationStatusList({Key? key}) : super(key: key);
+
+  @override
+  State<HobbyProductRegistrationStatusList> createState() => _HobbyProductRegistrationStatusListState();
+}
+
+class _HobbyProductRegistrationStatusListState extends State<HobbyProductRegistrationStatusList> {
+
+  List<String> _productTitle = [
+    '재봉틀 수업',
+    '십자수 수업',
+    '에그타르트 만들기',
+    '머랭쿠키 만들기'
+  ];
+
+  List<String> _productContent = [
+    '누구나 쉽게 따라할 수 있는 재봉틀 수업! 수선집 가기 싫고 집에서 간단하게 수선하고 싶진 않으신가요? 그럴땐 이 수업을 들어보세요!',
+    '유니크한 나만의 십자수 액자를 만들어보고 싶을 땐? 어디에도 팔지 않는 나만의 십자수 액자를 만들어보아요!',
+    '에그타르트를 집에 쟁여놓고 먹고싶어요. 어디서도 공개하지않은 최고의 비율로 탄생한 나만의 에그타르트 비법을 최초 공개합니다!!!',
+    '이거 완전 솜사탕 아니야?! 입안에서 살살녹는 머랭쿠키 누구나 만들 수 있다! 쉽게 배워보는 머랭쿠키 수업'
+  ];
+
+  List<String> _starRate = ['4.7', '4.3', '4.5', '4.2'];
+  List<String> _reviews = ['110', '337', '208', '185'];
+  List<String> _productRegisterDate = ['2022/12/10', '2022/11/23', '2022/11/09', '2022/10/13'];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: ListView.builder(
+        shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+          itemCount: 4,
+          itemBuilder: (BuildContext buildContext, int index) {
+        return Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20, top: 10),
+          child: Card(
+            elevation: 5,
+            shape: RoundedRectangleBorder( borderRadius: BorderRadius.circular(10)),
+            child: Container(
+              height: 200,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 180,
+                        height: 180,
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            fit: BoxFit.cover,
+                            image: AssetImage('assets/product/hobby${index+1}.jpg')
+                          ),
+                          borderRadius: BorderRadius.circular(15)
+                        ),
+                      ),
+                      VerticalDivider(),
+                      Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                  _productTitle[index],
+                                  style: TextStyle(fontSize: 13)
+                              ),
+                              Divider(thickness: 1,),
+                              Text(
+                                  _productContent[index],
+                                  maxLines: 3,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(fontSize: 11)
+                              ),
+                              Expanded(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Icon(Icons.star_rate, color: Colors.amber, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_starRate[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('별점', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                      ],
+                                    ),
+                                    SizedBox(height: 5),
+                                    Row(
+                                      children: [
+                                        Icon(Icons.rate_review_outlined, color: Colors.black, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_reviews[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('후기', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                      ],
+                                    ),
+                                    SizedBox(height: 5),
+                                    Row(
+                                      children: [
+                                        Icon(Icons.edit_calendar_outlined, color: Colors.black, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_productRegisterDate[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('등록일', style: TextStyle(fontSize: 12), textAlign: TextAlign.end,))
+                                      ],
+                                    )
+                                  ],
+                                ),
+                              )
+                            ],
+                          )
+                      )
+                    ],
+                  ),
+                )
+            ),
+          ),
+        );
+      })
+    );
+  }
+}

--- a/flutter/buy_idea/lib/component/seller/product_registration_status/knowhow_product_registration_status_list.dart
+++ b/flutter/buy_idea/lib/component/seller/product_registration_status/knowhow_product_registration_status_list.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+class KnowHowProductRegistrationStatusList extends StatefulWidget {
+  const KnowHowProductRegistrationStatusList({Key? key}) : super(key: key);
+
+  @override
+  State<KnowHowProductRegistrationStatusList> createState() => _KnowHowProductRegistrationStatusListState();
+}
+
+class _KnowHowProductRegistrationStatusListState extends State<KnowHowProductRegistrationStatusList> {
+
+  List<String> _productTitle = [
+    '계좌공개 실전매매 스켈핑 방법!',
+    '급등주보다 매일챙기는 매매법',
+  ];
+
+  List<String> _productContent = [
+    '계좌까지 공개한다! 실전매매 스켈핑 방법! 스켈레톤이 아니라 스켈핑이지롱 블라블라블라 가나다라초콜릿락스피릿리리맘보',
+    '급등주보다 매일챙기는 매매법! 급등이 곱등이 곱창 기타등등 허리허리 허리업 다운 청기들고 백기내려 하하',
+  ];
+
+  List<String> _starRate = ['4.8', '4.5'];
+  List<String> _reviews = ['20', '33'];
+  List<String> _productRegisterDate = ['2022/12/10', '2022/11/23'];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: ListView.builder(
+        shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+          itemCount: 2,
+          itemBuilder: (BuildContext buildContext, int index) {
+        return Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20, top: 10),
+          child: Card(
+            elevation: 5,
+            shape: RoundedRectangleBorder( borderRadius: BorderRadius.circular(10)),
+            child: Container(
+              height: 200,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 180,
+                        height: 180,
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            fit: BoxFit.cover,
+                            image: AssetImage('assets/product/knowhow${index+1}.jpg')
+                          ),
+                          borderRadius: BorderRadius.circular(15)
+                        ),
+                      ),
+                      VerticalDivider(),
+                      Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                  _productTitle[index],
+                                  style: TextStyle(fontSize: 13)
+                              ),
+                              Divider(thickness: 1,),
+                              Text(
+                                  _productContent[index],
+                                  maxLines: 3,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(fontSize: 11)
+                              ),
+                              Expanded(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Icon(Icons.star_rate, color: Colors.amber, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_starRate[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('별점', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                      ],
+                                    ),
+                                    SizedBox(height: 5),
+                                    Row(
+                                      children: [
+                                        Icon(Icons.rate_review_outlined, color: Colors.black, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_reviews[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('후기', style: TextStyle(fontSize: 12), textAlign: TextAlign.end))
+                                      ],
+                                    ),
+                                    SizedBox(height: 5),
+                                    Row(
+                                      children: [
+                                        Icon(Icons.edit_calendar_outlined, color: Colors.black, size: 14,),
+                                        SizedBox(width: 5),
+                                        Text(_productRegisterDate[index], style: TextStyle(fontSize: 12),),
+                                        Expanded(child: Text('등록일', style: TextStyle(fontSize: 12), textAlign: TextAlign.end,))
+                                      ],
+                                    )
+                                  ],
+                                ),
+                              )
+                            ],
+                          )
+                      )
+                    ],
+                  ),
+                )
+            ),
+          ),
+        );
+      })
+    );
+  }
+}

--- a/flutter/buy_idea/lib/component/seller/seller_common_app_bar.dart
+++ b/flutter/buy_idea/lib/component/seller/seller_common_app_bar.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 
 class SellerCommonAppBar extends StatelessWidget with PreferredSizeWidget {
-  const SellerCommonAppBar({Key? key, required this.appBar, this.title, this.leading, this.actions}) : super(key: key);
+  const SellerCommonAppBar({Key? key, this.title, this.leading, this.actions}) : super(key: key);
 
-  final AppBar appBar;
   final Widget? title;
   final Widget? leading;
   final List<Widget>? actions;
@@ -26,5 +25,5 @@ class SellerCommonAppBar extends StatelessWidget with PreferredSizeWidget {
 
   @override
   // TODO: implement preferredSize
-  Size get preferredSize => Size.fromHeight(appBar.preferredSize.height);
+  Size get preferredSize => Size.fromHeight(AppBar().preferredSize.height);
 }

--- a/flutter/buy_idea/lib/component/seller/seller_drawer.dart
+++ b/flutter/buy_idea/lib/component/seller/seller_drawer.dart
@@ -1,3 +1,4 @@
+import 'package:buy_idea/pages/seller/product_registration_status/product_registration_status_page.dart';
 import 'package:flutter/material.dart';
 
 class SellerDrawer extends StatefulWidget {
@@ -41,9 +42,11 @@ class _SellerDrawerState extends State<SellerDrawer> {
           SizedBox(height: 30),
           // Divider(),
           ListTile(
-            onTap: (){},
+            onTap: (){
+              Navigator.push(context, MaterialPageRoute(builder: (context) => ProductRegistrationStatusPage(nickname: widget.nickname,)));
+            },
             leading: Icon(Icons.local_mall_outlined, color: Colors.black),
-            title: Text('상품 관리'),
+            title: Text('상품 등록 현황'),
             trailing: Icon(Icons.navigate_next, color: Colors.black),
           ),
           Divider(),

--- a/flutter/buy_idea/lib/pages/seller/product_registration_status/product_registration_status_page.dart
+++ b/flutter/buy_idea/lib/pages/seller/product_registration_status/product_registration_status_page.dart
@@ -1,0 +1,76 @@
+import 'package:buy_idea/component/seller/product_registration_status/handmade_product_registration_status_list.dart';
+import 'package:buy_idea/component/seller/product_registration_status/hobby_product_registration_status_list.dart';
+import 'package:buy_idea/component/seller/product_registration_status/knowhow_product_registration_status_list.dart';
+import 'package:flutter/material.dart';
+
+class ProductRegistrationStatusPage extends StatefulWidget {
+  const ProductRegistrationStatusPage({Key? key, this.nickname}) : super(key: key);
+
+  final String? nickname;
+
+  @override
+  State<ProductRegistrationStatusPage> createState() => _ProductRegistrationStatusPageState();
+}
+
+class _ProductRegistrationStatusPageState extends State<ProductRegistrationStatusPage> with TickerProviderStateMixin {
+
+  late TabController tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    tabController = TabController(length: 3, vsync: this);
+  }
+
+  Widget _tabMenu(String menu) {
+    return Padding(
+      padding: EdgeInsets.all(15.0),
+      child: Text(
+          menu,
+          style: TextStyle(fontSize: 13, color: Colors.black)
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        iconTheme: IconThemeData(color: Colors.black),
+        centerTitle: true,
+        title: Text('${widget.nickname} 상품 등록 현황', style: TextStyle(color: Colors.black, fontSize: 15)),
+        elevation: 0,
+        bottom: PreferredSize(
+          child: Container(
+            height: AppBar().preferredSize.height,
+            decoration: const BoxDecoration(
+              border: Border(
+                  bottom: BorderSide(color: Colors.grey),
+                  top: BorderSide(color: Colors.grey, width: 0.1)
+              )
+            ),
+            child: TabBar(
+                controller: tabController,
+                indicatorColor: const Color(0xff2F4F4F),
+                tabs: [
+                  _tabMenu('핸드메이드'),
+                  _tabMenu('노하우'),
+                  _tabMenu('취미/특기'),
+                ],
+            ),
+          ),
+          preferredSize: Size.fromHeight(AppBar().preferredSize.height),
+        ),
+      ),
+      body: TabBarView(
+        controller: tabController,
+        children: [
+          HandmadeProductRegistrationStatusList(),
+          KnowHowProductRegistrationStatusList(),
+          HobbyProductRegistrationStatusList(),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/buy_idea/lib/pages/seller/seller_main_page.dart
+++ b/flutter/buy_idea/lib/pages/seller/seller_main_page.dart
@@ -39,7 +39,6 @@ class _SellerMainPageState extends State<SellerMainPage> {
     return Scaffold(
       drawer: SellerDrawer(nickname: memberNickname),
       appBar: SellerCommonAppBar(
-        appBar: AppBar(),
         title: GestureDetector(
           onTap: () {
             Navigator.push(context, MaterialPageRoute(builder: (context) => const SellerMainPage()));


### PR DESCRIPTION
**수정 사항 [DIY-SALES-APP-UI 15], [DIY-SALES-APP-UI 19]**
- Seller Common App Bar :
기존에는 AppBar의 높이를 상위 컴포넌트에서 넘겨받은 높이로 지정했으나 넘겨받지않고 AppBar() 위젯의 크기로 해당 컴포넌트에서 바로 지정해주는 형태로 수정
- Drawer :
'상품 관리' -> '상품 등록 현황' 네이밍 수정 및 상품 등록 현황 페이지 라우터 연결 기능 추가
- 메인페이지 :
Seller Common App Bar를 사용하면서 높이를 넘겨줬으나 App Bar 수정에 따라 높이를 지정해주는 코드 삭제

**완료 항목 [DIY-SALES-APP-UI 25]**
- 상품 등록 현황 페이지 :
-> 핸드메이드, 노하우, 취미/특기 각 카테고리에 따른 상품 등록 리스트 페이지로 이동하는 Tab Bar
-> 각 카테고리별로 판매자가 등록한 상품들의 정보와 별점, 후기, 등록일을 간략하게 나타내는 상품 카드