### PR TITLE
feat: [박선호] 주문 페이지의 주문 상품 정보 UI [DIY-SALES-APP-UI 60]

### DIFF
--- a/flutter/buy_idea/lib/component/buyer/order/delivery_address_input_form.dart
+++ b/flutter/buy_idea/lib/component/buyer/order/delivery_address_input_form.dart
@@ -44,12 +44,12 @@ class _DeliveryAddressInputFormState extends State<DeliveryAddressInputForm> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('배송지', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-          Divider(height: 20, color: Colors.grey, thickness: 0.2,),
+          Divider(height: 20, color: Colors.grey, thickness: 1,),
           Row(
             children: [
               SizedBox(
-                width: 80,
-                  child: Text('받는분', style: TextStyle(fontSize: 15, color: Colors.grey))
+                width: 70,
+                  child: Text('받는분', style: TextStyle(fontSize: 13, color: Colors.grey))
               ),
               Expanded(
                 child: TextFormField(
@@ -64,12 +64,12 @@ class _DeliveryAddressInputFormState extends State<DeliveryAddressInputForm> {
               )
             ],
           ),
-          Divider(height: 20, color: Colors.grey, thickness: 0.5,),
+          Divider(height: 20, color: Colors.grey, thickness: 1,),
           Row(
             children: [
               SizedBox(
-                width: 80,
-                  child: Text('전화번호', style: TextStyle(fontSize: 15, color: Colors.grey))
+                width: 70,
+                  child: Text('전화번호', style: TextStyle(fontSize: 13, color: Colors.grey))
               ),
               Expanded(
                 child: TextFormField(
@@ -85,13 +85,13 @@ class _DeliveryAddressInputFormState extends State<DeliveryAddressInputForm> {
               )
             ],
           ),
-          Divider(height: 20, color: Colors.grey, thickness: 0.8,),
+          Divider(height: 20, color: Colors.grey, thickness: 1,),
           Row(
             children: [
               SizedBox(
-                  width: 80,
+                  width: 70,
                   height: 130,
-                  child: Text('주소', style: TextStyle(fontSize: 15, color: Colors.grey))
+                  child: Text('주소', style: TextStyle(fontSize: 13, color: Colors.grey))
               ),
               _checkEnterAddress()
                   ? Expanded(

--- a/flutter/buy_idea/lib/component/buyer/order/ordering_customer_info_form.dart
+++ b/flutter/buy_idea/lib/component/buyer/order/ordering_customer_info_form.dart
@@ -37,12 +37,12 @@ class _OrderingCustomerInfoFormState extends State<OrderingCustomerInfoForm> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('주문 고객', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-          Divider(height: 20, color: Colors.grey),
+          Divider(height: 20, color: Colors.grey, thickness: 1,),
           Row(
             children: [
-              Text('닉네임', style: TextStyle(fontSize: 15, color: Colors.grey)),
-              SizedBox(width: 20),
-              Text(nickname, style: TextStyle(fontSize: 15)),
+              Text('닉네임', style: TextStyle(fontSize: 13, color: Colors.grey)),
+              SizedBox(width: 35),
+              Text(nickname, style: TextStyle(fontSize: 12)),
             ],
           ),
         ],

--- a/flutter/buy_idea/lib/component/buyer/order/ordering_info_form.dart
+++ b/flutter/buy_idea/lib/component/buyer/order/ordering_info_form.dart
@@ -1,0 +1,192 @@
+import 'package:buy_idea/api/spring_product_api.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class OrderingInfoForm extends StatefulWidget {
+  final List<RequestProduct> products;
+  final List<RequestProductImage> productImages;
+  final List<int> purchaseQuantityList;
+
+  const OrderingInfoForm({
+    Key? key,
+    required this.products,
+    required this.productImages,
+    required this.purchaseQuantityList
+  }) : super(key: key);
+
+  @override
+  State<OrderingInfoForm> createState() => _OrderingInfoFormState();
+}
+
+class _OrderingInfoFormState extends State<OrderingInfoForm> {
+
+  bool seeMore = false;
+
+  var f = NumberFormat('###,###,###,###');
+
+  int _getProductTotalPrice() {
+    int total = 0;
+    for(int i = 0; i < widget.products.length; i++) {
+      total += widget.products[i].price * widget.purchaseQuantityList[i];
+    }
+    return total;
+  }
+
+  _getTotalDeliveryFee() {
+    int total = 0;
+    for (int i = 0; i < widget.products.length; i++) {
+      if (widget.products[i].price * widget.purchaseQuantityList[i] < 50000) {
+        total += widget.products[i].deliveryFee;
+      }
+    }
+    return total;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: () {
+            if (seeMore == false) {
+              setState(() {
+                seeMore = true;
+              });
+            } else {
+              setState(() {
+                seeMore = false;
+              });
+            }
+          },
+          child: Container(
+            padding: EdgeInsets.all(15),
+            color: Colors.white,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('주문 상품 정보', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                SizedBox(height: 10),
+                SizedBox(
+                  width: MediaQuery.of(context).size.width,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      if (widget.products.length < 2)
+                        Expanded(child: Text('${widget.products[0].title}', style: TextStyle(fontSize: 11)))
+                      else
+                        Expanded(child: Text('${widget.products[0].title} 외 ${widget.products.length - 1}건', style: TextStyle(fontSize: 11))),
+                      SizedBox(width: 5),
+                      seeMore // 더보기 상태가 아니라면 아래쪽 화살표 / 더보기 상태라면 위쪽 화살표
+                          ? Icon(Icons.keyboard_arrow_up)
+                          : Icon(Icons.keyboard_arrow_down)
+                    ],
+                  ),
+                )
+              ],
+            ),
+          ),
+        ),
+        if (seeMore == true) ListView.builder(
+            physics: NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            itemCount: widget.products.length,
+            itemBuilder: (BuildContext context, int index) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: MediaQuery.of(context).size.width,
+                    padding: EdgeInsets.fromLTRB(15, 15, 15, 15),
+                    child: Text(widget.products[index].nickname, style: TextStyle(fontWeight: FontWeight.bold)),
+                  ),
+                  Container(
+                    width: MediaQuery.of(context).size.width,
+                    padding: EdgeInsets.fromLTRB(15, 20, 15, 20),
+                    color: Colors.white,
+                    child: Column(
+                      children: [
+                        Row(
+                          children: [
+                            Container(
+                              width: 30,
+                              height: 30,
+                              decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(5),
+                                  image: DecorationImage(
+                                      fit: BoxFit.cover,
+                                      image: AssetImage('assets/product/${widget.productImages[index].editedName}')
+                                  )
+                              ),
+                            ),
+                            SizedBox(width: 10),
+                            Text(widget.products[index].title, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13))
+                          ],
+                        ),
+                        SizedBox(height: 10),
+                        Row(
+                          children: [
+                            Expanded(
+                                child: Text('수량 : ${widget.purchaseQuantityList[index]}개', style: TextStyle(fontSize: 12),)
+                            ),
+                            Text('${f.format(widget.products[index].price * widget.purchaseQuantityList[index])}원', style: TextStyle(fontSize: 12))
+                          ],
+                        ),
+                        Divider(color: Colors.grey, height: 30, thickness: 1),
+                        Row(
+                          children: [
+                            Expanded(
+                                child: Text('배송비', style: TextStyle(fontSize: 12))
+                            ),
+                            if (widget.products[index].price * widget.purchaseQuantityList[index] < 50000)
+                              Text('${f.format(widget.products[index].deliveryFee)}원', style: TextStyle(fontSize: 12))
+                            else
+                              Text('무료배송')
+                          ],
+                        )
+                      ],
+                    ),
+                  )
+                ],
+              );
+            }
+        ),
+        SizedBox(height: 10),
+        Container(
+          width: MediaQuery.of(context).size.width,
+          color: Colors.white,
+          padding: EdgeInsets.all(15),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('결제 정보', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(child: Text('상품 금액', style: TextStyle(fontSize: 12))),
+                  Text('${f.format(_getProductTotalPrice())}원', style: TextStyle(fontSize: 12))
+                ],
+              ),
+              SizedBox(height: 10),
+              Row(
+                children: [
+                  Expanded(child: Text('배송비', style: TextStyle(fontSize: 12))),
+                  if (_getTotalDeliveryFee() == 0)
+                    Text('무료배송', style: TextStyle(fontSize: 12))
+                  else
+                    Text('${f.format(_getTotalDeliveryFee())}원', style: TextStyle(fontSize: 12))
+                ],
+              ),
+              Divider(color: Colors.grey, height: 30, thickness: 1),
+              Row(
+                children: [
+                  Expanded(child: Text('최종 결제 금액', style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold))),
+                  Text('${f.format(_getProductTotalPrice() + _getTotalDeliveryFee())}원', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold))
+                ],
+              )
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/flutter/buy_idea/lib/component/buyer/product/product_buy_and_shopping_cart_select_modal_sheet.dart
+++ b/flutter/buy_idea/lib/component/buyer/product/product_buy_and_shopping_cart_select_modal_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:buy_idea/pages/account/sign_in_page.dart';
+import 'package:buy_idea/pages/buyer/order/order_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get/get.dart';
@@ -11,6 +12,7 @@ class ProductBuyAndShoppingCartSelectModalSheet extends StatefulWidget {
   final int deliveryFee;
   final int freeDeliveryFee;
   final int stock;
+  final int productNo;
 
   const ProductBuyAndShoppingCartSelectModalSheet({
     Key? key,
@@ -19,7 +21,8 @@ class ProductBuyAndShoppingCartSelectModalSheet extends StatefulWidget {
     required this.productPrice,
     required this.deliveryFee,
     required this.freeDeliveryFee,
-    required this.stock
+    required this.stock,
+    required this.productNo
   }) : super(key: key);
 
   @override
@@ -296,7 +299,9 @@ class _ProductBuyAndShoppingCartSelectModalSheetState extends State<ProductBuyAn
                       ),
                       onPressed: () {
                         if (checkSignIn()) {
-                          // TODO: 배송지 입력 페이지로 이동
+                          List<int> productNoList = [widget.productNo];
+                          List<int> purchaseQuantityList = [purchaseQuantity];
+                          Get.off(OrderPage(productNoList: productNoList, purchaseQuantityList: purchaseQuantityList));
                         } else {
                           showDialog(
                               context: context,

--- a/flutter/buy_idea/lib/pages/buyer/order/order_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/order/order_page.dart
@@ -4,6 +4,7 @@ import 'package:buy_idea/component/buyer/order/delivery_address_input_form.dart'
 import 'package:buy_idea/component/buyer/order/ordering_customer_info_form.dart';
 import 'package:buy_idea/component/buyer/order/ordering_info_form.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class OrderPage extends StatefulWidget {
   final List<int> productNoList;
@@ -28,6 +29,8 @@ class _OrderPageState extends State<OrderPage> {
   final TextEditingController cityController = TextEditingController();
   final TextEditingController streetController = TextEditingController();
   final TextEditingController addressDetailController = TextEditingController();
+
+  var f = NumberFormat('###,###,###,###');
 
   var future;
 
@@ -93,9 +96,52 @@ class _OrderPageState extends State<OrderPage> {
                 ),
               ),
             ),
+            bottomSheet: Container(
+              width: MediaQuery.of(context).size.width,
+              height: 80,
+              padding: EdgeInsets.only(left: 10, right: 10),
+              decoration: BoxDecoration(
+                  color: Colors.white,
+                  border: Border(top: BorderSide(color: Colors.black12))
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ElevatedButton(
+                    onPressed: () {
+
+                    },
+                    child: Text('${f.format(_getProductTotalPrice() + _getTotalDeliveryFee())}원 결제하기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),),
+                    style: ElevatedButton.styleFrom(
+                        elevation: 0,
+                        fixedSize: Size(MediaQuery.of(context).size.width - 20, 60),
+                        primary: Color(0xff2F4F4F)
+                    ),
+                  ),
+                ],
+              ),
+            ),
           );
         }
       },
     );
+  }
+
+  int _getProductTotalPrice() {
+    int total = 0;
+    for(int i = 0; i < products.length; i++) {
+      total += products[i].price * widget.purchaseQuantityList[i];
+    }
+    return total;
+  }
+
+  _getTotalDeliveryFee() {
+    int total = 0;
+    for (int i = 0; i < products.length; i++) {
+      if (products[i].price * widget.purchaseQuantityList[i] < 50000) {
+        total += products[i].deliveryFee;
+      }
+    }
+    return total;
   }
 }

--- a/flutter/buy_idea/lib/pages/buyer/order/order_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/order/order_page.dart
@@ -1,10 +1,19 @@
+import 'package:buy_idea/api/spring_product_api.dart';
 import 'package:buy_idea/component/buyer/app_bar/title_top_bar.dart';
 import 'package:buy_idea/component/buyer/order/delivery_address_input_form.dart';
 import 'package:buy_idea/component/buyer/order/ordering_customer_info_form.dart';
+import 'package:buy_idea/component/buyer/order/ordering_info_form.dart';
 import 'package:flutter/material.dart';
 
 class OrderPage extends StatefulWidget {
-  const OrderPage({Key? key}) : super(key: key);
+  final List<int> productNoList;
+  final List<int> purchaseQuantityList;
+
+  const OrderPage({
+    Key? key,
+    required this.productNoList,
+    required this.purchaseQuantityList
+  }) : super(key: key);
 
   @override
   State<OrderPage> createState() => _OrderPageState();
@@ -20,33 +29,73 @@ class _OrderPageState extends State<OrderPage> {
   final TextEditingController streetController = TextEditingController();
   final TextEditingController addressDetailController = TextEditingController();
 
+  var future;
+
+  List<RequestProduct> products = [];
+  List<RequestProductImage> productImages = [];
+
+  Future<void> _loadProducts() async {
+    for(var i = 0; i < widget.productNoList.length; i++) {
+      products.add(await SpringProductApi().productDetailsInfo(widget.productNoList[i]));
+      productImages.add(await SpringProductApi().productThumbnailImage(widget.productNoList[i]));
+    }
+  }
+
+  @override
+  void initState() {
+    future = _loadProducts();
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: TitleTopBar(titleText: '상품 결제'),
-      body: SingleChildScrollView(
-        child: Form(
-          key: _formKey,
-          child: Container(
+    return FutureBuilder(
+      future: future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          // 메소드가 완료되지 않았다면 로딩표시 애니메이션을 화면에 띄움
+          return Container(
             width: MediaQuery.of(context).size.width,
-            color: Colors.grey,
-            child: Column(
-              children: [
-                OrderingCustomerInfoForm(),
-                SizedBox(height: 10),
-                DeliveryAddressInputForm(
-                  recipientController: recipientController,
-                  phoneController: phoneController,
-                  zipcodeController: zipcodeController,
-                  cityController: cityController,
-                  streetController: streetController,
-                  addressDetailController: addressDetailController,
-                )
-              ],
+            height: 100,
+            color: Colors.white,
+            child: Center(
+              child: CircularProgressIndicator(
+                color: Color(0xff2F4F4F),
+              ),
             ),
-          ),
-        ),
-      ),
+          );
+        } else {
+          return Scaffold(
+            appBar: TitleTopBar(titleText: '상품 결제'),
+            body: SingleChildScrollView(
+              child: Form(
+                key: _formKey,
+                child: Container(
+                  width: MediaQuery.of(context).size.width,
+                  color: Colors.grey[200],
+                  child: Column(
+                    children: [
+                      OrderingCustomerInfoForm(),
+                      SizedBox(height: 10),
+                      DeliveryAddressInputForm(
+                        recipientController: recipientController,
+                        phoneController: phoneController,
+                        zipcodeController: zipcodeController,
+                        cityController: cityController,
+                        streetController: streetController,
+                        addressDetailController: addressDetailController,
+                      ),
+                      SizedBox(height: 10),
+                      OrderingInfoForm(products: products, productImages: productImages, purchaseQuantityList: widget.purchaseQuantityList),
+                      SizedBox(height: 80)
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/flutter/buy_idea/lib/pages/buyer/product/product_details_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/product/product_details_page.dart
@@ -255,6 +255,7 @@ made in Korea
                               deliveryFee: product.deliveryFee,
                               freeDeliveryFee: freeDeliveryFee,
                               stock: product.stock,
+                              productNo: product.productNo,
                             );
                           }
                       );


### PR DESCRIPTION
### 추가 항목
**[DIY-SALES-APP-UI 60]**
    ☑️ 장바구니 및 상품 상세 페이지에서 구매 진행 시 보여지는 주문 페이지의 주문 상품 정보 UI 구현

**[DIY-SALES-APP-UI 61]**
    ☑️ 장바구니 및 상품 상세 페이지에서 구매 진행 시 보여지는 주문 페이지의 하단에 고정되어 보여지는 결제 bottom sheet UI 구현

### 수정 항목
**[DIY-SALES-APP-UI 6]**
    ☑️ text 사이즈 및 divider 사이즈 수정
**[DIY-SALES-APP-UI 59]**
    ☑️ text 사이즈 및 divider 사이즈 수정
**[DIY-SALES-APP-UI 32]**
    ☑️ 구매 모달 창 파라미터 추가