### PR TITLE
feat: [박선호] 판매자가 상품과 관련된 건수와 매출의 집계를 요청할 때 산출하여 반환하는 시스템 [DIY-SALES-PROCESS 53]

### DIFF
--- a/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/OrderInfoController.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/OrderInfoController.java
@@ -65,12 +65,4 @@ public class OrderInfoController {
 
         return orderInfoService.sellerOrderInfoListCount(request);
     }
-
-    @GetMapping("/seller/sales/{seller}")
-    public Long salesOfSeller(@PathVariable("seller") String seller) {
-        log.info("salesOfSeller()");
-        log.info("seller : " + seller);
-
-        return orderInfoService.getSalesOfSeller(seller);
-    }
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/entity/order/OrderInfo.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/entity/order/OrderInfo.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 
 @Entity
 @Data
-@ToString(exclude = {"address", "product"} )
+@ToString(exclude = {"deliveryAddress", "product"} )
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderInfo {

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/repository/order/OrderInfoRepository.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/repository/order/OrderInfoRepository.java
@@ -36,7 +36,9 @@ public interface OrderInfoRepository extends JpaRepository<OrderInfo, Long> {
 
     @Query("select sum(o.quantity * o.product.price) from OrderInfo o join o.product " +
             "where o.product.nickname = :seller and o.orderStatus = :orderStatus ")
-    Long getSalesBySeller(@Param("seller") String seller,
-                          @Param("orderStatus") OrderStatus orderStatus
-    );
+    Long calculateSalesBySeller(@Param("seller") String seller,
+                                @Param("orderStatus") OrderStatus orderStatus);
+
+    @Query("select count(o) from OrderInfo o join o.product where o.product.nickname = :seller")
+    Long countOrdersBySeller(@Param("seller") String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/ProductRepository.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/ProductRepository.java
@@ -51,4 +51,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
                                                        @Param("category") String category,
                                                        @Param("productNo") Long productNo,
                                                        Pageable pageable);
+
+    @Query("select count(p) from Product p where p.nickname = :seller")
+    Long countProductsBySeller(@Param("seller") String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/qna/QnARepository.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/qna/QnARepository.java
@@ -21,4 +21,7 @@ public interface QnARepository extends JpaRepository<QnA, Long> {
             "where p.nickname = :nickname and q.answerStatus = :answerStatus order by q.qnaNo desc")
     List<QnA> findQnaHistoryByNicknameAndAnswerStatus(@Param("nickname") String nickname,
                                                       @Param("answerStatus") AnswerStatus answerStatus);
+
+    @Query("select count(q) from QnA q join q.product where q.product.nickname = :seller")
+    Long countQnABySeller(@Param("seller") String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/review/ReviewRepository.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/repository/product/review/ReviewRepository.java
@@ -36,4 +36,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r join fetch r.product p where r.writer = :writer and p.productNo = :productNo")
     Optional<Review> findReviewByWriterOnSpecificProduct(@Param("writer") String writer,
                                                          @Param("productNo") Long productNo);
+
+    @Query("select count(r) from Review r join r.product where r.product.nickname = :seller")
+    Long countReviewsBySeller(@Param("seller") String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoService.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoService.java
@@ -21,6 +21,4 @@ public interface OrderInfoService {
     public List<SellerProductOrderStatusResponse> getSellerProductOrderStatus(String nickname);
 
     Long sellerOrderInfoListCount(OrderStatusRequest request);
-
-    public Long getSalesOfSeller(String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoServiceImpl.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoServiceImpl.java
@@ -228,19 +228,6 @@ public class OrderInfoServiceImpl implements OrderInfoService {
         return orderInfoCount;
     }
 
-    /**
-     * 판매자의 상품 중 배송 완료된 건에 한하여 매출을 구해 반환하는 Service Impl
-     *
-     * @param seller 판매자 상호명(닉네임)
-     * @return 배송 완료 건의 (주문 상품 개수 * 주문한 상품의 금액)을 모두 합한 값
-     */
-    @Override
-    public Long getSalesOfSeller(String seller) {
-        final String DELIVERED = "배송 완료";
-        OrderStatus orderStatus = getOrderStatus(DELIVERED);
-        return orderInfoRepository.getSalesBySeller(seller, orderStatus);
-    }
-
     private OrderStatus getOrderStatus(String orderStatus) {
         return switch (orderStatus) {
             case "결제 완료" -> OrderStatus.PAYMENT_COMPLETE;

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/SellerService.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/SellerService.java
@@ -2,10 +2,13 @@ package team_project.buy_idea.service.seller;
 
 import team_project.buy_idea.controller.seller.request.SellerProfileRequest;
 import team_project.buy_idea.service.seller.response.SellerInfoResponse;
+import team_project.buy_idea.service.seller.response.SellerTotalResponse;
 
 public interface SellerService {
 
     void registerSellerProfile(SellerProfileRequest sellerProfileRequest);
 
     SellerInfoResponse sellerInfoResponseByNickname(String nickname);
+
+    SellerTotalResponse getSellerTotalInfo(String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/SellerServiceImpl.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/SellerServiceImpl.java
@@ -4,12 +4,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import team_project.buy_idea.controller.seller.request.SellerProfileRequest;
 import team_project.buy_idea.entity.member.Member;
+import team_project.buy_idea.entity.order.OrderStatus;
 import team_project.buy_idea.entity.seller.CompanyInfo;
 import team_project.buy_idea.entity.seller.SellerProfile;
 import team_project.buy_idea.repository.member.MemberRepository;
+import team_project.buy_idea.repository.order.OrderInfoRepository;
+import team_project.buy_idea.repository.product.ProductRepository;
+import team_project.buy_idea.repository.product.qna.QnARepository;
+import team_project.buy_idea.repository.product.review.ReviewRepository;
 import team_project.buy_idea.repository.seller.CompanyInfoRepository;
 import team_project.buy_idea.repository.seller.SellerRepository;
 import team_project.buy_idea.service.seller.response.SellerInfoResponse;
+import team_project.buy_idea.service.seller.response.SellerTotalResponse;
 
 import java.util.Optional;
 
@@ -24,6 +30,18 @@ public class SellerServiceImpl implements SellerService{
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private QnARepository qnARepository;
+
+    @Autowired
+    private OrderInfoRepository orderInfoRepository;
 
     @Override
     public void registerSellerProfile(SellerProfileRequest sellerProfileRequest) {
@@ -77,5 +95,29 @@ public class SellerServiceImpl implements SellerService{
             return sellerInfoResponse;
         }
         throw new RuntimeException("등록된 업체 정보가 없습니다.");
+    }
+
+    @Override
+    public SellerTotalResponse getSellerTotalInfo(String seller) {
+
+        final String DELIVERED = "배송 완료";
+        OrderStatus orderStatus = switch (DELIVERED) {
+            case "결제 완료" -> OrderStatus.PAYMENT_COMPLETE;
+            case "배송중" -> OrderStatus.DELIVERING;
+            case "배송 완료" -> OrderStatus.DELIVERED;
+            case "취소" -> OrderStatus.CANCEL;
+            case "환불" -> OrderStatus.REFUND;
+            case "교환" -> OrderStatus.EXCHANGE;
+            default -> null;
+        };
+
+        Long products = productRepository.countProductsBySeller(seller);
+        Long reviews = reviewRepository.countReviewsBySeller(seller);
+        Long qnA = qnARepository.countQnABySeller(seller);
+        Long orders = orderInfoRepository.countOrdersBySeller(seller);
+        Long sales = orderInfoRepository.calculateSalesBySeller(seller, orderStatus);
+
+        SellerTotalResponse response = new SellerTotalResponse(products, reviews, qnA, orders, sales);
+        return response;
     }
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/response/SellerTotalResponse.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/seller/response/SellerTotalResponse.java
@@ -1,0 +1,17 @@
+package team_project.buy_idea.service.seller.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerTotalResponse {
+
+    private Long totalProduct;
+    private Long totalReview;
+    private Long totalQnA;
+    private Long totalOrder;
+    private Long totalSales;
+}

--- a/spring/buy_idea/src/test/java/team_project/buy_idea/order/OrderTestCase.java
+++ b/spring/buy_idea/src/test/java/team_project/buy_idea/order/OrderTestCase.java
@@ -111,10 +111,4 @@ public class OrderTestCase {
 
         System.out.println(orderInfoService.sellerOrderInfoListCount(orderStatusRequest));
     }
-
-    @Test
-    void getSalesTest() {
-        Long sales = orderInfoService.getSalesOfSeller("ANNAsSHOP");
-        System.out.println(sales);
-    }
 }

--- a/spring/buy_idea/src/test/java/team_project/buy_idea/seller/SellerTestCase.java
+++ b/spring/buy_idea/src/test/java/team_project/buy_idea/seller/SellerTestCase.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import team_project.buy_idea.controller.seller.request.CompanyInfoRequest;
 import team_project.buy_idea.controller.seller.request.SellerProfileRequest;
 import team_project.buy_idea.service.seller.SellerService;
+import team_project.buy_idea.service.seller.response.SellerTotalResponse;
 
 @SpringBootTest
 public class SellerTestCase {
@@ -26,5 +27,12 @@ public class SellerTestCase {
         String nickname = "gggg";
 
         System.out.println(sellerService.sellerInfoResponseByNickname(nickname));
+    }
+
+    @Test
+    void getSellerTotalInfoTest() {
+        SellerTotalResponse response = sellerService.getSellerTotalInfo("ANNAsSHOP");
+
+        System.out.println(response);
     }
 }


### PR DESCRIPTION
**[DIY-SALES-PROCESS 53]**
- [x]  seller total controller
- [x]  seller total response
- [x]  product, review, QnA, orderInfo repository 합계 및 카운트 쿼리
- [x]  seller service, service impl
- [x]  test

**refator : [DIY-SALES-PROCESS 51]**
- 기존에 orderinfo쪽에서 매출만을 전달하는 방식에서 seller에서 다른 데이터들과 함께 response로 보내기 위해 리팩토링
- 리팩토링 항목 - repository 쿼리를 제외한 controller, service, service impl, test를 seller쪽 로직으로 이동

**fix : [DIY-SALES-PROCESS 15]**
- @ToString 어노테이션의 exclude 파라미터의 address를 변수명 변경에 따라 deliveryAddress로 변경하지 않아 경고 발생으로 수정