### PR TITLE
update : [임재범] vue에서 Spring에 요청한 주문내역의 갯수를 카운트하여 그 갯수를 vue로 보내주는 시스템 [DIY-S…

### DIFF
--- a/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/OrderInfoController.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/OrderInfoController.java
@@ -59,10 +59,10 @@ public class OrderInfoController {
         return orderInfoService.getSellerProductOrderStatus(nickname);
     }
 
-    @PostMapping("/seller-order-info-list-count")
-    public Long sellerOrderInfoListCount (@RequestBody OrderStatusRequest request) {
-        log.info("SellerOrderInfoListCount()" + request);
+    @PostMapping("/seller-order-info-list-count/{seller}")
+    public List<Long> sellerOrderInfoListCount (@PathVariable("seller") String seller) {
+        log.info("SellerOrderInfoListCount()" + seller);
 
-        return orderInfoService.sellerOrderInfoListCount(request);
+        return orderInfoService.sellerOrderInfoListCount(seller);
     }
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoService.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoService.java
@@ -20,5 +20,5 @@ public interface OrderInfoService {
 
     public List<SellerProductOrderStatusResponse> getSellerProductOrderStatus(String nickname);
 
-    Long sellerOrderInfoListCount(OrderStatusRequest request);
+    public List<Long> sellerOrderInfoListCount(String seller);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoServiceImpl.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/OrderInfoServiceImpl.java
@@ -215,17 +215,20 @@ public class OrderInfoServiceImpl implements OrderInfoService {
     }
 
     @Override
-    public Long sellerOrderInfoListCount(OrderStatusRequest request){
-        log.info(request.getNickname());
-        log.info(request.getOrderStatus());
-        String sellerNickname = request.getNickname();
-        String orderStatus = request.getOrderStatus();
+    public  List<Long> sellerOrderInfoListCount(String seller){
 
-        OrderStatus status = getOrderStatus(orderStatus);
 
-        Long orderInfoCount = orderInfoRepository.countByProductNicknameAndOrderStatus(sellerNickname, status);
+        List<Long> orderInfoCountArr = new ArrayList<>();
 
-        return orderInfoCount;
+
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.PAYMENT_COMPLETE));
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.DELIVERING));
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.DELIVERED));
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.CANCEL));
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.EXCHANGE));
+        orderInfoCountArr.add(orderInfoRepository.countByProductNicknameAndOrderStatus(seller, OrderStatus.REFUND));
+
+        return orderInfoCountArr;
     }
 
     private OrderStatus getOrderStatus(String orderStatus) {

--- a/spring/buy_idea/src/test/java/team_project/buy_idea/order/OrderTestCase.java
+++ b/spring/buy_idea/src/test/java/team_project/buy_idea/order/OrderTestCase.java
@@ -107,8 +107,7 @@ public class OrderTestCase {
 
     @Test
     void getSellerOrderCount(){
-        OrderStatusRequest orderStatusRequest = new OrderStatusRequest("쿤", "결제 완료");
 
-        System.out.println(orderInfoService.sellerOrderInfoListCount(orderStatusRequest));
+        System.out.println(orderInfoService.sellerOrderInfoListCount("쿤"));
     }
 }

--- a/vue/frontend/src/components/seller/OrderManageForm.vue
+++ b/vue/frontend/src/components/seller/OrderManageForm.vue
@@ -68,7 +68,7 @@
       <v-expansion-panel>
         <v-expansion-panel-header @click="requestPaymentCompletedList">{{ paymentComplete }}</v-expansion-panel-header>
         <v-expansion-panel-content>
-          <OrderStatusForm :order-status="paymentComplete" :order-info-list="sellerOrderList"></OrderStatusForm>
+          <OrderStatusForm :order-status="paymentComplete" :order-info-list="sellerOrderList" ></OrderStatusForm>
         </v-expansion-panel-content>
       </v-expansion-panel>
 

--- a/vue/frontend/src/store/actions.js
+++ b/vue/frontend/src/store/actions.js
@@ -916,11 +916,11 @@ export default {
     },
 
     requestSellerOrderListCountFromSpring ({ commit }, payload) {
-        console.log('requestSellerOrderListFromSpring()')
-        const {nickname, orderStatus} = payload;
+        console.log('requestSellerOrderListCountFromSpring()')
+        const seller = payload;
         console.log(payload);
 
-        return axios.post(`http://localhost:8888/order/seller-order-info-list-count`, {nickname, orderStatus})
+        return axios.post(`http://localhost:8888/order/seller-order-info-list-count/${seller}`)
             .then((res) => {
                 console.log(res.data)
 

--- a/vue/frontend/src/store/states.js
+++ b/vue/frontend/src/store/states.js
@@ -38,7 +38,7 @@ export default {
     recentlyViewedProductList: [],
     productRatingValue: [],
     productReadRatingValue: [],
-    sellerOrderListCount: 0,
+    sellerOrderListCount: [],
     reviewWriteCheckValue: [],
     sellerInfoData: {}
 }

--- a/vue/frontend/src/views/seller/OrderManageView.vue
+++ b/vue/frontend/src/views/seller/OrderManageView.vue
@@ -18,40 +18,14 @@ export default {
   async mounted() {
 
     const nickname = this.$store.state.memberInfoAfterSignIn.nickname;
-    // const orderStatus = this.paymentComplete;
-    for (let i = 0; i < 6; i++) {
-      if(i==0){
-        const orderStatus = this.paymentComplete
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfPaymentComplete = this.$store.state.sellerOrderListCount;
-      } else if(i==1){
-        const orderStatus = this.inDelivery
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfInDelivery = this.$store.state.sellerOrderListCount;
-      } else if(i==2){
-        const orderStatus = this.deliveryCompleted
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfDeliveryCompleted = this.$store.state.sellerOrderListCount;
-      } else if(i==3){
-        const orderStatus = this.canceled
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfCanceled = this.$store.state.sellerOrderListCount;
-      } else if(i==4){
-        const orderStatus = this.exchanged
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfExchanged = this.$store.state.sellerOrderListCount;
-      } else if(i==5){
-        const orderStatus = this.returned
-        await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-        this.NumberOfReturned = this.$store.state.sellerOrderListCount;
-      }
-    }
+    await this.requestSellerOrderListCountFromSpring(nickname)
 
-    // for (let i = 0; i < this.orderStatus.length; i++) {
-    //   let orderStatus = this.orderStatus[i].status
-    //   await this.requestSellerOrderListCountFromSpring({nickname, orderStatus})
-    //   this.NumberOfPaymentComplete = this.$store.state.sellerOrderListCount;
-    // }
+    this.NumberOfPaymentComplete = this.$store.state.sellerOrderListCount[0];
+    this.NumberOfInDelivery = this.$store.state.sellerOrderListCount[1];
+    this.NumberOfDeliveryCompleted = this.$store.state.sellerOrderListCount[2];
+    this.NumberOfCanceled = this.$store.state.sellerOrderListCount[3];
+    this.NumberOfExchanged = this.$store.state.sellerOrderListCount[4];
+    this.NumberOfReturned = this.$store.state.sellerOrderListCount[5];
 
 
   },


### PR DESCRIPTION
▶ vue에서 받아온 nickname과 OrderStatus에 해당하는 주문내역을 반환하던 것에서
nickname만 받아서 해당 닉네임과 일치하는 주문내역 중 결제완료/배송중/배송완료/취소/교환/환불 의 각 갯수를 카운트하여 ArrayList에 담아 그 ArrayList를 한 번에 리턴하는 것으로 변경함.

▶Spring에서 카운트한 결제완료/배송중/배송완료/취소/교환/환불 갯수를 ArrayList에 담아 vue에 보내고, 그 ArrayList에 담긴 각 갯수를 Web페이지에 표시하는 것으로 변경.(트래픽 감소를 위함)