### PR TITLE
fix: [박선호] 특정 판매자가 상품 상세 페이지로 이동 시 해당 상품의 판매자와 일치할 때의 상품 상세 페이지 UI [DIY-SALES-APP-UI 115]

### DIFF
--- a/flutter/buy_idea/lib/api/spring_product_api.dart
+++ b/flutter/buy_idea/lib/api/spring_product_api.dart
@@ -5,15 +5,24 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class SpringProductApi {
-  static const String httpUri = '192.168.0.8:8888';
+  static const String httpUri = '192.168.0.12:8888';
   static var SearchProductResponse;
 
   Future<List<RequestProductThumbnailInfo>> firstProductList(
-      String category, int productSize) async {
-    var response = await http.get(
-      Uri.http(httpUri, '/product/list',
-          {'category': category, 'productSize': productSize.toString()}),
+      String category, int productSize, String viewMode) async {
+
+    var body = {
+      'category' : category,
+      'productSize' : productSize,
+      'filter' : viewMode
+    };
+
+    var jsonBody = json.encode(body);
+
+    var response = await http.post(
+      Uri.http(httpUri, '/product/list'),
       headers: {"Content-Type": "application/json"},
+      body: jsonBody
     );
 
     if (response.statusCode == 200) {
@@ -33,14 +42,22 @@ class SpringProductApi {
   }
 
   Future<List<RequestProductThumbnailInfo>> nextProductList(
-      int productNo, String category, int productSize) async {
-    var response = await http.get(
-      Uri.http(httpUri, '/product/list/next', {
-        'productNo': productNo.toString(),
-        'category': category,
-        'productSize': productSize.toString()
-      }),
+      int productNo, String category, int productSize, String viewMode, List<int> productNoList) async {
+
+    var body = {
+      'productNo' : productNo,
+      'category' : category,
+      'productSize' : productSize,
+      'filter' : viewMode,
+      'productNoList' : productNoList
+    };
+
+    var jsonBody = json.encode(body);
+
+    var response = await http.post(
+      Uri.http(httpUri, '/product/list/next'),
       headers: {"Content-Type": "application/json"},
+      body: jsonBody
     );
 
     if (response.statusCode == 200) {
@@ -192,6 +209,7 @@ class RequestProduct {
   String infoNotice;
   int deliveryFee;
   int stock;
+  int viewCnt;
   String regDate;
   String updDate;
 
@@ -206,6 +224,7 @@ class RequestProduct {
       required this.infoNotice,
       required this.deliveryFee,
       required this.stock,
+      required this.viewCnt,
       required this.regDate,
       required this.updDate});
 
@@ -221,6 +240,7 @@ class RequestProduct {
         infoNotice: json['productInfo']['infoNotice'],
         deliveryFee: json['productInfo']['deliveryFee'],
         stock: json['productInfo']['stock'],
+        viewCnt: json['productInfo']['viewCnt'],
         regDate: json['productInfo']['regDate'],
         updDate: json['productInfo']['updDate']);
   }

--- a/flutter/buy_idea/lib/component/buyer/category/category_product_list_from.dart
+++ b/flutter/buy_idea/lib/component/buyer/category/category_product_list_from.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:buy_idea/component/buyer/category/category_product.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:get/get.dart';
 
 import '../../../api/spring_product_api.dart';
@@ -7,11 +10,19 @@ import '../../../pages/buyer/product/product_details_page.dart';
 import 'category_product_card.dart';
 
 class CategoryProductListForm extends StatefulWidget {
-  CategoryProductListForm(
-      {Key? key, required this.category_list, required this.categoryName})
-      : super(key: key);
+
   final List<CategoryProduct> category_list;
   final String categoryName;
+  final String viewMode;
+  final List<int> productNoList;
+
+  CategoryProductListForm({
+    Key? key,
+    required this.category_list,
+    required this.categoryName,
+    required this.viewMode,
+    required this.productNoList
+  }) : super(key: key);
 
   @override
   State<CategoryProductListForm> createState() =>
@@ -33,36 +44,59 @@ class _CategoryProductListFormState extends State<CategoryProductListForm> {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-        child: GridView.count(
-            controller: _scrollController,
-            scrollDirection: Axis.vertical,
-            crossAxisCount: 2,
-            childAspectRatio: MediaQuery.of(context).size.height / 1400,
-            children: List.generate(widget.category_list.length, (index) {
-              return CategoryProductCard(
-                productNo: widget.category_list[index].productNo,
-                title: widget.category_list[index].title,
-                image: widget.category_list[index].image,
-                price: widget.category_list[index].price,
-                nickname: widget.category_list[index].nickname,
-                press: () {
-                  Get.to(ProductDetailsPage(
-                      productNo: widget.category_list[index].productNo));
-                },
-              );
-            })));
+        child: Stack(
+          children: [
+            GridView.count(
+                padding: const EdgeInsets.only(bottom: 20),
+                controller: _scrollController,
+                scrollDirection: Axis.vertical,
+                crossAxisCount: 2,
+                childAspectRatio: MediaQuery.of(context).size.height / 1400,
+                children: List.generate(widget.category_list.length, (index) {
+                  return CategoryProductCard(
+                    productNo: widget.category_list[index].productNo,
+                    title: widget.category_list[index].title,
+                    image: widget.category_list[index].image,
+                    price: widget.category_list[index].price,
+                    nickname: widget.category_list[index].nickname,
+                    press: () {
+                      Get.to(ProductDetailsPage(
+                          productNo: widget.category_list[index].productNo));
+                    },
+                  );
+                })),
+            if (isLoading)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: const [
+                  Padding(
+                    padding: EdgeInsets.only(bottom: 10),
+                    child: SpinKitThreeBounce(
+                      color: Color(0xff2F4F4F),
+                      size: 25,
+                    ),
+                  ),
+                ],
+              )
+          ],
+        ));
   }
 
   _scrollListener() async {
     if (_scrollController.offset >=
         _scrollController.position.maxScrollExtent &&
         !_scrollController.position.outOfRange) {
+      setState(() {
+        isLoading = true;
+      });
 
       var productCount = widget.category_list.length;
 
       List<RequestProductThumbnailInfo> nextProductList =
       await SpringProductApi().nextProductList(
-          widget.category_list[productCount-1].productNo, widget.categoryName, 4);
+          widget.category_list[productCount-1].productNo, widget.categoryName, 4, widget.viewMode, widget.productNoList);
 
       for (var i = 0; i < nextProductList.length; i++) {
         RequestProductImage image = await SpringProductApi()
@@ -75,12 +109,14 @@ class _CategoryProductListFormState extends State<CategoryProductListForm> {
           title: nextProductList[i].title,
           price: nextProductList[i].price,
         ));
+        widget.productNoList.add(nextProductList[i].productNo);
         debugPrint(widget.category_list.toString());
       }
 
       setState(() {
+        widget.productNoList;
         print("comes to bottom $isLoading");
-        isLoading = true;
+        isLoading = false;
       });
     }
   }

--- a/flutter/buy_idea/lib/component/buyer/home/home_product_list_form.dart
+++ b/flutter/buy_idea/lib/component/buyer/home/home_product_list_form.dart
@@ -33,7 +33,7 @@ class _HomeHandmadeState extends State<HomeCategoryProduct> {
 
   addProductList() async {
     List<RequestProductThumbnailInfo> productList =
-        await SpringProductApi().firstProductList(widget.category, 4);
+        await SpringProductApi().firstProductList(widget.category, 4, '최신순');
     switch (widget.category) {
       case "핸드메이드":
         home_handmade_list.clear();

--- a/flutter/buy_idea/lib/component/seller/product_registration_status/product_registration_status_list.dart
+++ b/flutter/buy_idea/lib/component/seller/product_registration_status/product_registration_status_list.dart
@@ -15,13 +15,15 @@ class ProductRegistrationStatusList extends StatefulWidget {
   final String category;
   final int listSize;
   final int nextListSize;
+  final String memberType;
 
   const ProductRegistrationStatusList({
     Key? key,
     required this.seller,
     required this.category,
     required this.listSize,
-    required this.nextListSize
+    required this.nextListSize,
+    required this.memberType
   }) : super(key: key);
 
   @override
@@ -102,7 +104,7 @@ class _ProductRegistrationStatusListState extends State<ProductRegistrationStatu
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
                       child: InkWell(
                         onTap: () {
-                          Get.to(ProductDetailsPage(productNo: productList[index].productNo, seller: productList[index].seller));
+                          Get.to(ProductDetailsPage(productNo: productList[index].productNo, memberType: widget.memberType));
                         },
                         child: Container(
                           height: 200,

--- a/flutter/buy_idea/lib/pages/buyer/category/handmade_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/category/handmade_page.dart
@@ -1,11 +1,10 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 
 import '../../../api/spring_product_api.dart';
 import '../../../component/buyer/app_bar/no_logo_top_bar.dart';
 import '../../../component/buyer/category/category_product.dart';
 import '../../../component/buyer/category/category_product_list_from.dart';
-
-bool isLoading = false;
 
 class HandmadePage extends StatefulWidget {
   const HandmadePage({Key? key}) : super(key: key);
@@ -15,18 +14,26 @@ class HandmadePage extends StatefulWidget {
 }
 
 class _HandmadePageState extends State<HandmadePage> {
+
+  bool isLoading = false;
+
+  String viewMode = '최신순';
+  List<String> dropdownItemList = ['최신순', '인기순', '후기순', '높은 가격순', '낮은 가격순'];
+
+  List<int> productNoList = [];
+
   @override
   void initState() {
+    super.initState();
+    addProductList(viewMode);
+  }
+
+  addProductList(String viewMode) async {
     setState(() {
       isLoading = false;
     });
-    super.initState();
-    addProductList();
-  }
-
-  addProductList() async {
     List<RequestProductThumbnailInfo> productList =
-        await SpringProductApi().firstProductList('핸드메이드', 8);
+        await SpringProductApi().firstProductList('핸드메이드', 8, viewMode);
     category_handmade_list.clear();
     for (var i = 0; i < productList.length; i++) {
       RequestProductImage image = await SpringProductApi()
@@ -39,9 +46,11 @@ class _HandmadePageState extends State<HandmadePage> {
         title: productList[i].title,
         price: productList[i].price,
       ));
+      productNoList.add(productList[i].productNo);
       debugPrint(category_handmade_list.toString());
     }
     setState(() {
+      productNoList;
       isLoading = true;
     });
   }
@@ -64,12 +73,50 @@ class _HandmadePageState extends State<HandmadePage> {
         appBar: const NoLogoTopBar(),
         body: Column(
           children: [
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 40,
+              color: Colors.white,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  DropdownButton2(
+                    value: viewMode,
+                    items: dropdownItemList.map((item) => DropdownMenuItem<String>(
+                      value: item,
+                      child: Text(
+                        item,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold
+                        ),
+                      )
+                    )).toList(),
+                    onChanged: (String? item) {
+                      setState(() {
+                        viewMode = item!;
+                        addProductList(viewMode);
+                      });
+                    },
+                    icon: Icon(Icons.arrow_drop_down),
+                    iconOnClick: Icon(Icons.arrow_drop_up),
+                    iconSize: 20,
+                    buttonWidth: 120,
+                    buttonHeight: 50,
+                    buttonPadding: EdgeInsets.all(5),
+                  ),
+                  SizedBox(width: 10)
+                ],
+              ),
+            ),
             CategoryProductListForm(
               category_list: category_handmade_list,
               categoryName: '핸드메이드',
+              viewMode: viewMode,
+              productNoList: productNoList,
             )
           ],
-        ),
+        )
       );
     }
   }

--- a/flutter/buy_idea/lib/pages/buyer/category/hobby_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/category/hobby_page.dart
@@ -1,11 +1,10 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 
 import '../../../api/spring_product_api.dart';
 import '../../../component/buyer/app_bar/no_logo_top_bar.dart';
 import '../../../component/buyer/category/category_product.dart';
 import '../../../component/buyer/category/category_product_list_from.dart';
-
-bool isLoading = false;
 
 class HobbyPage extends StatefulWidget {
   const HobbyPage({Key? key}) : super(key: key);
@@ -15,18 +14,29 @@ class HobbyPage extends StatefulWidget {
 }
 
 class _HobbyPageState extends State<HobbyPage> {
+
+  bool isLoading = false;
+
+  String viewMode = '최신순';
+  List<String> dropdownItemList = ['최신순', '인기순', '후기순', '높은 가격순', '낮은 가격순'];
+
+  List<int> productNoList = [];
+
   @override
   void initState() {
     setState(() {
       isLoading = false;
     });
     super.initState();
-    addProductList();
+    addProductList(viewMode);
   }
 
-  addProductList() async {
+  addProductList(String viewMode) async {
+    setState(() {
+      isLoading = false;
+    });
     List<RequestProductThumbnailInfo> productList =
-        await SpringProductApi().firstProductList('취미/특기', 8);
+        await SpringProductApi().firstProductList('취미/특기', 8, viewMode);
     category_hobby_list.clear();
     for (var i = 0; i < productList.length; i++) {
       RequestProductImage image = await SpringProductApi()
@@ -39,9 +49,11 @@ class _HobbyPageState extends State<HobbyPage> {
         title: productList[i].title,
         price: productList[i].price,
       ));
+      productNoList.add(productList[i].productNo);
       debugPrint(category_hobby_list.toString());
     }
     setState(() {
+      productNoList;
       isLoading = true;
     });
   }
@@ -64,9 +76,46 @@ class _HobbyPageState extends State<HobbyPage> {
         appBar: const NoLogoTopBar(),
         body: Column(
           children: [
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 40,
+              color: Colors.white,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  DropdownButton2(
+                    value: viewMode,
+                    items: dropdownItemList.map((item) => DropdownMenuItem<String>(
+                        value: item,
+                        child: Text(
+                          item,
+                          style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold
+                          ),
+                        )
+                    )).toList(),
+                    onChanged: (String? item) {
+                      setState(() {
+                        viewMode = item!;
+                        addProductList(viewMode);
+                      });
+                    },
+                    icon: Icon(Icons.arrow_drop_down),
+                    iconSize: 20,
+                    buttonWidth: 120,
+                    buttonHeight: 50,
+                    buttonPadding: EdgeInsets.all(5),
+                  ),
+                  SizedBox(width: 10)
+                ],
+              ),
+            ),
             CategoryProductListForm(
               category_list: category_hobby_list,
               categoryName: '취미/특기',
+              viewMode: viewMode,
+              productNoList: productNoList,
             )
           ],
         ),

--- a/flutter/buy_idea/lib/pages/buyer/category/knowhow_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/category/knowhow_page.dart
@@ -1,11 +1,11 @@
+
+import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 
 import '../../../api/spring_product_api.dart';
 import '../../../component/buyer/app_bar/no_logo_top_bar.dart';
 import '../../../component/buyer/category/category_product.dart';
 import '../../../component/buyer/category/category_product_list_from.dart';
-
-bool isLoading = false;
 
 class KnowhowPage extends StatefulWidget {
   const KnowhowPage({Key? key}) : super(key: key);
@@ -15,18 +15,26 @@ class KnowhowPage extends StatefulWidget {
 }
 
 class _KnowhowPageState extends State<KnowhowPage> {
+
+  bool isLoading = false;
+
+  String viewMode = '최신순';
+  List<String> dropdownItemList = ['최신순', '인기순', '후기순', '높은 가격순', '낮은 가격순'];
+
+  List<int> productNoList = [];
+
   @override
   void initState() {
+    super.initState();
+    addProductList(viewMode);
+  }
+
+  addProductList(String viewMode) async {
     setState(() {
       isLoading = false;
     });
-    super.initState();
-    addProductList();
-  }
-
-  addProductList() async {
     List<RequestProductThumbnailInfo> productList =
-        await SpringProductApi().firstProductList('노하우', 8);
+        await SpringProductApi().firstProductList('노하우', 8, viewMode);
     category_knowhow_list.clear();
     for (var i = 0; i < productList.length; i++) {
       RequestProductImage image = await SpringProductApi()
@@ -39,9 +47,11 @@ class _KnowhowPageState extends State<KnowhowPage> {
         title: productList[i].title,
         price: productList[i].price,
       ));
+      productNoList.add(productList[i].productNo);
       debugPrint(category_knowhow_list.toString());
     }
     setState(() {
+      productNoList;
       isLoading = true;
     });
   }
@@ -64,9 +74,46 @@ class _KnowhowPageState extends State<KnowhowPage> {
         appBar: const NoLogoTopBar(),
         body: Column(
           children: [
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 40,
+              color: Colors.white,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  DropdownButton2(
+                    value: viewMode,
+                    items: dropdownItemList.map((item) => DropdownMenuItem<String>(
+                        value: item,
+                        child: Text(
+                          item,
+                          style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold
+                          ),
+                        )
+                    )).toList(),
+                    onChanged: (String? item) {
+                      setState(() {
+                        viewMode = item!;
+                        addProductList(viewMode);
+                      });
+                    },
+                    icon: Icon(Icons.arrow_drop_down),
+                    iconSize: 20,
+                    buttonWidth: 120,
+                    buttonHeight: 50,
+                    buttonPadding: EdgeInsets.all(5),
+                  ),
+                  SizedBox(width: 10)
+                ],
+              ),
+            ),
             CategoryProductListForm(
               category_list: category_knowhow_list,
               categoryName: '노하우',
+              viewMode: viewMode,
+              productNoList: productNoList,
             )
           ],
         ),

--- a/flutter/buy_idea/lib/pages/buyer/product/product_details_page.dart
+++ b/flutter/buy_idea/lib/pages/buyer/product/product_details_page.dart
@@ -15,8 +15,8 @@ import '../../../component/buyer/product/QnA/product_qna_form.dart';
 
 class ProductDetailsPage extends StatefulWidget {
   final int productNo;
-  final String? seller;
-  const ProductDetailsPage({Key? key, required this.productNo, this.seller}) : super(key: key);
+  final String? memberType;
+  const ProductDetailsPage({Key? key, required this.productNo, this.memberType}) : super(key: key);
 
   @override
   State<ProductDetailsPage> createState() => _ProductDetailsPageState();
@@ -97,14 +97,14 @@ class _ProductDetailsPageState extends State<ProductDetailsPage> with TickerProv
               iconTheme: IconThemeData(color: Colors.black),
               backgroundColor: Colors.white,
               centerTitle: true,
-              title: widget.seller != nickname ? GestureDetector(
+              title: widget.memberType != '판매자' ? GestureDetector(
                 child: Image.asset('assets/buydia_logo.png', width: 80, height: 50),
                 onTap: () {
                     Get.offAll(MainPage());
                 },
               ) : Image.asset('assets/buydia_logo.png', width: 80, height: 50),
               elevation: 0,
-              actions: widget.seller != nickname ? [
+              actions: widget.memberType != '판매자' ? [
                 IconButton(
                     onPressed: () {
                       Get.to(ShoppingBucketPage());
@@ -169,7 +169,7 @@ class _ProductDetailsPageState extends State<ProductDetailsPage> with TickerProv
                   ),
                 ];
               },
-              body: widget.seller != nickname ? Padding(
+              body: widget.memberType != '판매자' ? Padding(
                 padding: EdgeInsets.only(bottom: 60),
                 child: TabBarView(
                     controller: tabController,
@@ -188,7 +188,7 @@ class _ProductDetailsPageState extends State<ProductDetailsPage> with TickerProv
                   ]
               ),
             ),
-            bottomSheet: widget.seller != nickname ? Container(
+            bottomSheet: widget.memberType != '판매자' ? Container(
               width: MediaQuery.of(context).size.width,
               height: 60,
               decoration: BoxDecoration(

--- a/flutter/buy_idea/lib/pages/seller/product_registration_status/product_registration_status_page.dart
+++ b/flutter/buy_idea/lib/pages/seller/product_registration_status/product_registration_status_page.dart
@@ -72,9 +72,9 @@ class _ProductRegistrationStatusPageState extends State<ProductRegistrationStatu
       body: TabBarView(
         controller: tabController,
         children: [
-          ProductRegistrationStatusList(seller: widget.nickname!, category: _handmade, listSize: 4, nextListSize: 4),
-          ProductRegistrationStatusList(seller: widget.nickname!, category: _knowhow, listSize: 4, nextListSize: 4),
-          ProductRegistrationStatusList(seller: widget.nickname!, category: _hobby, listSize: 4, nextListSize: 4),
+          ProductRegistrationStatusList(seller: widget.nickname!, category: _handmade, listSize: 4, nextListSize: 4, memberType: '판매자'),
+          ProductRegistrationStatusList(seller: widget.nickname!, category: _knowhow, listSize: 4, nextListSize: 4, memberType: '판매자'),
+          ProductRegistrationStatusList(seller: widget.nickname!, category: _hobby, listSize: 4, nextListSize: 4, memberType: '판매자'),
         ],
       ),
     );

--- a/flutter/buy_idea/pubspec.yaml
+++ b/flutter/buy_idea/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   switcher_button: ^0.0.4
   flutter_spinkit: ^5.1.0
   smooth_page_indicator: ^1.0.0+2
+  dropdown_button2: ^1.9.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**fix : [DIY-SALES-APP-UI 115]**
판매자만 해당 기능들이 보여지지 않아야되지만 비회원까지 안 보이게되는 버그 발생

- 기존에 판매자 닉네임이 일치하면 안보이는 로직에서 닉네임을 넘겨주지 않았을 때 null 값이 들어와 안 보이게 된 것으로 추정
→ 따라서 닉네임이 아닌 멤버타입이 판매자 일 경우에만 안 보여지도록 수정

**[DIY-SALES-APP-UI 129]**
- [x] DropdownButton2 라이브러리 설치

**update : [DIY-SALES-APP-UI 50]**
- first product list method : 필터 파라미터 추가
- next product list method : 필터, productNoList 파라미터 추가
- 서버쪽 mapping 방식이 get → post로 변경됨에 따라 get에서 post로 수정
- 요청에 담아서 보낼 body 추가

**update : [DIY-SALES-APP-UI 54]**
- category product list form : 다음 상품 불러올 때 로딩 표시 적용 및 api 수정에 따라 필터 및 productNoList 전달
- 카테고리별  페이지 : 상품 리스트 필터 dropdown button UI 추가 및 api 수정에 맞게 필터 파라미터 전달