### PR TITLE
fix: [임재범] 상품 상세정보 페이지에서 문의를 탭했을때 나타나는 UI [DIY-SALES-APP-UI 98]

### DIFF
--- a/flutter/buy_idea/lib/component/buyer/product/QnA/product_open_qna_card.dart
+++ b/flutter/buy_idea/lib/component/buyer/product/QnA/product_open_qna_card.dart
@@ -155,7 +155,7 @@ _writerChangePrivate() {
                         ),
                         SizedBox(width: 10.0),
                         Container(
-                          width: 370.0,
+                          width: 350.0,
                           child: Text(
                             widget.answer,
                             style: TextStyle(fontSize: 14),


### PR DESCRIPTION
▶(오류수정) 문의글 리스트 표시하는 창에서 픽셀 초과 오류가 나던 것 사이즈 조정하여 수정.