### PR TITLE
fix2: [진건오] 장바구니 상품 삭제 시스템[DIY-SALES-PROCESS 24]

### DIFF
--- a/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/shoppingBucket/ShoppingBucketController.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/controller/order/shoppingBucket/ShoppingBucketController.java
@@ -3,6 +3,7 @@ package team_project.buy_idea.controller.order.shoppingBucket;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketDeleteItemRequest;
 import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketRequest;
 import team_project.buy_idea.entity.order.shoppingBucket.ShoppingBucketItem;
 import team_project.buy_idea.service.order.shopppingbucket.ShoppingBucketService;
@@ -33,11 +34,8 @@ public class ShoppingBucketController {
     }
 
     @DeleteMapping("/shopping-bucket-list/delete")
-    public void deleteShoppingBucketProduct(@RequestParam("itemId") Long itemId,
-                                            @RequestParam("nickname") String nickname) {
+    public void deleteShoppingBucketProduct(@RequestBody ShoppingBucketDeleteItemRequest shoppingBucketDeleteItemRequest) {
 
-        log.info("deleteShoppingBucketProduct" + itemId + nickname);
-
-        bucketService.deleteShoppingBucketProduct(itemId, nickname);
+        bucketService.deleteShoppingBucketProduct(shoppingBucketDeleteItemRequest);
     }
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/entity/order/shoppingBucket/ShoppingBucketItem.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/entity/order/shoppingBucket/ShoppingBucketItem.java
@@ -18,11 +18,11 @@ public class ShoppingBucketItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itemId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shopping_bucket_id")
     private ShoppingBucket shoppingBucket;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/shopppingbucket/ShoppingBucketService.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/shopppingbucket/ShoppingBucketService.java
@@ -1,6 +1,7 @@
 package team_project.buy_idea.service.order.shopppingbucket;
 
 
+import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketDeleteItemRequest;
 import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketRequest;
 import team_project.buy_idea.entity.order.shoppingBucket.ShoppingBucketItem;
 
@@ -12,5 +13,5 @@ public interface ShoppingBucketService {
 
     public List<ShoppingBucketItem> shoppingBucketItemList(String nickname);
 
-    public void deleteShoppingBucketProduct(Long itemId, String nickname);
+    public void deleteShoppingBucketProduct(ShoppingBucketDeleteItemRequest deleteItemRequest);
 }

--- a/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/shopppingbucket/ShoppingBucketServiceImpl.java
+++ b/spring/buy_idea/src/main/java/team_project/buy_idea/service/order/shopppingbucket/ShoppingBucketServiceImpl.java
@@ -3,6 +3,7 @@ package team_project.buy_idea.service.order.shopppingbucket;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketDeleteItemRequest;
 import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketRequest;
 import team_project.buy_idea.entity.member.Member;
 import team_project.buy_idea.entity.order.shoppingBucket.ShoppingBucket;
@@ -78,37 +79,40 @@ public class ShoppingBucketServiceImpl implements ShoppingBucketService{
     }
 
     @Override
-    public void deleteShoppingBucketProduct(Long itemId, String nickname) {
-        List<ShoppingBucketItem> shoppingBucketItems = this.shoppingBucketItemList(nickname);
+    public void deleteShoppingBucketProduct(ShoppingBucketDeleteItemRequest deleteItemRequest) {
+        List<ShoppingBucketItem> shoppingBucketItems = this.shoppingBucketItemList(deleteItemRequest.getNickname());
+        Long[] itemId = deleteItemRequest.getItemId();
 
-        if (shoppingBucketItems.isEmpty()){
-            Optional<Member> maybeMember = memberRepository.findBuyDiaMemberByNickname(nickname);
-            Member member = maybeMember.get();
+        for (int i = 0; i < itemId.length; i++) {
+            if (shoppingBucketItems.isEmpty()){
+                Optional<Member> maybeMember = memberRepository.findBuyDiaMemberByNickname(deleteItemRequest.getNickname());
+                Member member = maybeMember.get();
 
-            ShoppingBucket shoppingBucket = ShoppingBucket.builder()
-                    .member(member)
-                    .shoppingBucketTotalCnt(0)
-                    .build();
-
-            shoppingBucketRepository.save(shoppingBucket);
-        } else {
-            bucketProductRepository.deleteById(itemId);
-            List<ShoppingBucketItem> shoppingBucketItemList = this.shoppingBucketItemList(nickname);
-
-            if (shoppingBucketItemList.size() >= 0){
-                Optional<ShoppingBucket> maybeShoppingBucket = shoppingBucketRepository.findByNickname(nickname);
-                ShoppingBucket shoppingBucket = maybeShoppingBucket.get();
-
-                shoppingBucket.setShoppingBucketTotalCnt(shoppingBucket.getShoppingBucketTotalCnt() -1);
+                ShoppingBucket shoppingBucket = ShoppingBucket.builder()
+                        .member(member)
+                        .shoppingBucketTotalCnt(0)
+                        .build();
 
                 shoppingBucketRepository.save(shoppingBucket);
             } else {
-                Optional<ShoppingBucket> maybeShoppingBucket = shoppingBucketRepository.findByNickname(nickname);
-                ShoppingBucket shoppingBucket = maybeShoppingBucket.get();
+                bucketProductRepository.deleteById(itemId[i]);
+                List<ShoppingBucketItem> shoppingBucketItemList = this.shoppingBucketItemList(deleteItemRequest.getNickname());
 
-                shoppingBucket.setShoppingBucketTotalCnt(0);
+                if (shoppingBucketItemList.size() >= 0){
+                    Optional<ShoppingBucket> maybeShoppingBucket = shoppingBucketRepository.findByNickname(deleteItemRequest.getNickname());
+                    ShoppingBucket shoppingBucket = maybeShoppingBucket.get();
 
-                shoppingBucketRepository.save(shoppingBucket);
+                    shoppingBucket.setShoppingBucketTotalCnt(shoppingBucket.getShoppingBucketTotalCnt() -1);
+
+                    shoppingBucketRepository.save(shoppingBucket);
+                } else {
+                    Optional<ShoppingBucket> maybeShoppingBucket = shoppingBucketRepository.findByNickname(deleteItemRequest.getNickname());
+                    ShoppingBucket shoppingBucket = maybeShoppingBucket.get();
+
+                    shoppingBucket.setShoppingBucketTotalCnt(0);
+
+                    shoppingBucketRepository.save(shoppingBucket);
+                }
             }
         }
     }

--- a/spring/buy_idea/src/test/java/team_project/buy_idea/order/shoppingBucket/ShoppingBucketTest.java
+++ b/spring/buy_idea/src/test/java/team_project/buy_idea/order/shoppingBucket/ShoppingBucketTest.java
@@ -3,6 +3,7 @@ package team_project.buy_idea.order.shoppingBucket;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketDeleteItemRequest;
 import team_project.buy_idea.controller.order.shoppingBucket.request.ShoppingBucketRequest;
 import team_project.buy_idea.service.member.MemberService;
 import team_project.buy_idea.service.member.request.MemberSignInRequest;
@@ -56,9 +57,8 @@ public class ShoppingBucketTest {
 
     @Test
     void deleteShoppingBucketProduct(){
-        Long itemId = 1L;
-        String nickname = "jjjj";
+        ShoppingBucketDeleteItemRequest shoppingBucketDeleteItemRequest = new ShoppingBucketDeleteItemRequest(new Long[]{18L, 19L, 20L}, "gggg");
 
-        shoppingBucketService.deleteShoppingBucketProduct(itemId, nickname);
+        shoppingBucketService.deleteShoppingBucketProduct(shoppingBucketDeleteItemRequest);
     }
 }

--- a/vue/frontend/src/components/order/OrderForm.vue
+++ b/vue/frontend/src/components/order/OrderForm.vue
@@ -330,11 +330,13 @@ export default {
               //장바구니에서 결제 시 장바구니에 담긴 상품 삭제
             if (this.productReadCheckValue === false) {
               const nickname = this.$store.state.memberInfoAfterSignIn.nickname
-              for (let i = 0; i < this.productInfoByShoppingCart.length; i++) {
-                let itemId = this.productInfoByShoppingCart[i].itemId
+              let itemId = []
 
-                await this.requestDeleteShoppingCartItemsAtCheckoutFromSpring({itemId, nickname})
+              for (let i = 0; i < this.productInfoByShoppingCart.length; i++) {
+                itemId.push(this.productInfoByShoppingCart[i].itemId)
               }
+
+              await this.requestDeleteShoppingCartItemsAtCheckoutFromSpring({itemId, nickname})
             }
             await this.$router.push({name: "HomeView"})
             break

--- a/vue/frontend/src/components/shoppingCart/ShoppingCartForm.vue
+++ b/vue/frontend/src/components/shoppingCart/ShoppingCartForm.vue
@@ -222,7 +222,8 @@ export default {
       'requestDeleteShoppingBucketItemFromSpring'
     ]),
     async deleteSelectProduct(productItemId) {
-      const itemId = productItemId
+      const itemId = []
+      itemId.push(productItemId)
       const nickname = this.$store.state.memberInfoAfterSignIn.nickname
       await this.requestDeleteShoppingBucketItemFromSpring({itemId, nickname});
     },

--- a/vue/frontend/src/store/actions.js
+++ b/vue/frontend/src/store/actions.js
@@ -369,7 +369,7 @@ export default {
         console.log("requestDeleteShoppingBucketItemFromSpring");
 
         await axios.delete('http://localhost:8888/order/shopping-bucket-list/delete', {
-            params: {
+            data: {
                 itemId: payload.itemId,
                 nickname: payload.nickname
             }
@@ -389,9 +389,10 @@ export default {
      */
     // eslint-disable-next-line no-empty-pattern
     async requestDeleteShoppingCartItemsAtCheckoutFromSpring({}, payload) {
+        console.log(payload.itemId)
 
         await axios.delete('http://localhost:8888/order/shopping-bucket-list/delete', {
-            params: {
+            data: {
                 itemId: payload.itemId,
                 nickname: payload.nickname
             }


### PR DESCRIPTION
### [DIY-SALES-PROCESS 24]
- controller
  - @RequestParam으로 각각 데이터를 전달 받던 걸 @RequestBody로 전달받도록 변경
  - RequestBody로 변경되면서 데이터를 가공해줄 request 설계
  - request에는 Long타입 배열의 itemId 변수와 nickname 변수 설계

- service
  - 장바구니 상품 삭제 로직을 for문으로 감싸 장바구니 상품이 여러 개일 경우 반복해서 돌리도록 설계

### [DIY-SALES-WEB-UI 89]
- 기존 for문을 통해 axios를 여러번 요청했던걸 배열 변수를 생성하여
해당 변수에 상품을 담아주기만 하고 한번만 요청하도록 변경

- 이 과정에서 params로 데이터를 넘겨주었지만 특히 배열 데이터를 넘기려면
params는 무리가 있어서 data로 변경 후 매핑하도록 설계
(서버에서 해당 컨트롤러가 RequestBody로 변경되기도 함)